### PR TITLE
fix crash when a player is punched by a mod

### DIFF
--- a/pvp.lua
+++ b/pvp.lua
@@ -125,7 +125,7 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 minetest.register_on_punchplayer(function(player, hitter, time_from_last_punch, tool_capabilities, dir, damage)
-	if not hitter:is_player() then
+	if not minetest.is_player(hitter) then
 		return false
 	end
 


### PR DESCRIPTION
According to the lua api, `register_on_punchplayer`'s hitter can be nil.
Currently the mod would crash with `attempt to index local 'hitter' (a nil value)`